### PR TITLE
fix: `main.js`에서 잘못된 import 구문 제거

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -72,13 +72,11 @@ export function redrawCanvas() {
 function drawBbox(obj, isSelected, isDrawing = false) {
     const [x1, y1, x2, y2] = obj.bbox;
     ui.ctx.lineWidth = isSelected ? 4 / state.transform.scale : 2 / state.transform.scale;
-
     let color = 'rgba(59, 130, 246, 1)'; // Default to blue for selected/drawing
     if (!isSelected && obj.className) {
         color = getColorForClass(obj.className);
     }
     ui.ctx.strokeStyle = color;
-
     if (isDrawing) ui.ctx.setLineDash([5, 5]);
     ui.ctx.strokeRect(Math.min(x1,x2), Math.min(y1,y2), Math.abs(x2 - x1), Math.abs(y2 - y1));
     ui.ctx.setLineDash([]);

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,9 @@
 import { initUI } from './ui.js';
 import { initializeEventListeners } from './events.js';
-import { loadDefaultConfig } from './file.js';
 
-async function initialize() {
+function initialize() {
     initUI();
     initializeEventListeners();
-    await loadDefaultConfig();
 }
 
 initialize();


### PR DESCRIPTION
`main.js`에서 이전 커밋에서 삭제된 `loadDefaultConfig` 함수를 import하려고 시도하여 발생하던 `Uncaught SyntaxError`를 수정했습니다.

이제 애플리케이션이 정상적으로 시작됩니다.