### PR TITLE
refactor: Implement in-memory data management and ZIP export

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         <input type="file" id="dirLoader" webkitdirectory multiple class="hidden">
         <button id="btnLoadDir" class="btn btn-tonal" disabled>이미지 폴더 열기</button>
 
-        <button id="btnSave" class="btn btn-filled" disabled>JSON 저장 (S)</button>
+        <button id="btnSave" class="btn btn-filled" disabled>전체 JSON 저장 (ZIP)</button>
         
         <div class="flex-grow"></div>
 
@@ -60,6 +60,7 @@
     <footer class="p-2 shadow-inner flex-shrink-0 flex justify-between items-center text-sm" style="background-color: var(--md-sys-color-surface-container-high); border-top: 1px solid var(--md-sys-color-outline-variant);"></footer>
 
     <div id="toast-popup"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script type="module" src="src/main.js"></script>
 </body>
 </html>

--- a/src/events.js
+++ b/src/events.js
@@ -2,7 +2,7 @@ import * as state from './state.js';
 import { ui, updateAllUI, updateBboxInfoUI, updateKeypointListUI, updateInfoBarUI } from './ui.js';
 import { redrawCanvas, centerImage, handleResize } from './canvas.js';
 import { getMousePos, screenToWorld, isPointInBbox, getResizeHandleAt, showNotification } from './utils.js';
-import { navigateImage, saveCurrentAnnotation, handleConfigFile, handleDirectorySelection } from './file.js';
+import { navigateImage, saveAllAnnotationsToZip, handleConfigFile, handleDirectorySelection } from './file.js';
 import { showDeleteConfirmModal } from './modal.js';
 
 export function initializeEventListeners() {
@@ -10,7 +10,7 @@ export function initializeEventListeners() {
     ui.configLoader.addEventListener('change', handleConfigFile);
     ui.btnLoadDir.addEventListener('click', () => ui.dirLoader.click());
     ui.dirLoader.addEventListener('change', handleDirectorySelection);
-    ui.btnSave.addEventListener('click', saveCurrentAnnotation);
+    ui.btnSave.addEventListener('click', saveAllAnnotationsToZip);
     ui.btnPrev.addEventListener('click', () => navigateImage(-1));
     ui.btnNext.addEventListener('click', () => navigateImage(1));
     ui.btnAddObject.addEventListener('click', () => enterBboxDrawingMode());
@@ -249,7 +249,7 @@ async function handleKeyDown(e) {
     if (e.altKey || e.target.tagName === 'INPUT') return;
     switch (e.key.toLowerCase()) {
         case 'a': e.preventDefault(); enterBboxDrawingMode(); break;
-        case 's': e.preventDefault(); saveCurrentAnnotation(); break;
+        case 's': e.preventDefault(); saveAllAnnotationsToZip(); break;
         case 'z': if (e.ctrlKey || e.metaKey) { e.preventDefault(); undo(); } break;
         case 'escape':
             e.preventDefault();

--- a/src/file.js
+++ b/src/file.js
@@ -56,10 +56,36 @@ export async function handleDirectorySelection(e) {
     ui.canvasLoader.style.display = 'flex';
     try {
         const files = Array.from(e.target.files);
-        state.setImageFiles(files.filter(f => /\.(png|jpe?g)$/i.test(f.name)).sort((a,b) => a.name.localeCompare(b.name)));
-        state.setJsonFiles(files.filter(f => /\.json$/i.test(f.name)));
+        const imageFiles = files.filter(f => /\.(png|jpe?g)$/i.test(f.name)).sort((a, b) => a.name.localeCompare(b.name));
+        const jsonFiles = files.filter(f => /\.json$/i.test(f.name));
+        const jsonFileMap = new Map(jsonFiles.map(f => [f.name.replace(/\.json$/i, ''), f]));
 
-        if (state.imageFiles.length === 0) throw new Error('폴더에 지원하는 이미지 파일이 없습니다.');
+        if (imageFiles.length === 0) {
+            throw new Error('폴더에 지원하는 이미지 파일이 없습니다.');
+        }
+
+        state.setImageFiles(imageFiles);
+        state.setAnnotationData({}); // 기존 데이터 초기화
+
+        let loadedJsonCount = 0;
+        for (const imageFile of imageFiles) {
+            const imageName = imageFile.name.replace(/\.[^/.]+$/, "");
+            const jsonFile = jsonFileMap.get(imageName);
+            const imageFilename = imageFile.name;
+
+            if (jsonFile) {
+                try {
+                    const data = JSON.parse(await jsonFile.text());
+                    state.updateAnnotationData(imageFilename, data);
+                    loadedJsonCount++;
+                } catch (err) {
+                    showNotification(`${jsonFile.name} 파싱 오류. 새로 시작합니다.`, 'error', ui);
+                    state.updateAnnotationData(imageFilename, { image_path: imageFilename, objects: [] });
+                }
+            } else {
+                state.updateAnnotationData(imageFilename, { image_path: imageFilename, objects: [] });
+            }
+        }
 
         ui.btnSave.disabled = false;
         ui.btnPrev.disabled = false;
@@ -70,12 +96,12 @@ export async function handleDirectorySelection(e) {
         ui.btnLoadDir.classList.replace('btn-tonal', 'btn-success');
 
         await navigateImage(0, true);
-        showNotification(`${state.imageFiles.length}개 이미지, ${state.jsonFiles.length}개 JSON 로드됨`, 'success', ui);
+        showNotification(`${state.imageFiles.length}개 이미지, ${loadedJsonCount}개 JSON 로드됨`, 'success', ui);
 
     } catch (error) {
         showNotification(error.message, 'error', ui);
         state.setImageFiles([]);
-        state.setJsonFiles([]);
+        state.setAnnotationData({});
         ui.btnLoadDir.textContent = '이미지 폴더 열기';
         ui.btnLoadDir.classList.replace('btn-success', 'btn-tonal');
     } finally {
@@ -130,53 +156,61 @@ function loadAndDrawImage(index) {
 
 async function loadAnnotationForImage(index) {
     const imageFilename = state.imageFiles[index].name;
-    const jsonFilename = imageFilename.replace(/\.[^/.]+$/, "") + ".json";
-    const annotationFile = state.jsonFiles.find(f => f.name === jsonFilename);
 
+    // 데이터는 이미 handleDirectorySelection에서 로드되었으므로, 해당 데이터를 사용하기만 하면 됩니다.
+    // 히스토리를 리셋하고 현재 상태를 첫 히스토리로 추가합니다.
     state.resetHistory();
 
-    if (annotationFile) {
-        try {
-            const data = JSON.parse(await annotationFile.text());
-            if (data.objects) {
-                state.updateAnnotationData(imageFilename, data);
-            } else if (data.keypoints) {
-                state.updateAnnotationData(imageFilename, {
-                    image_path: data.image_path,
-                    objects: [{ id: `obj_${Date.now()}`, bbox: null, keypoints: data.keypoints }]
-                });
-                showNotification('이전 버전 JSON을 변환했습니다. BBox를 다시 지정해주세요.', 'info', ui);
-            }
-        } catch (e) {
-            showNotification(`${jsonFilename} 파싱 오류. 새로 시작합니다.`, 'error', ui);
-            state.updateAnnotationData(imageFilename, { image_path: imageFilename, objects: [] });
-        }
-    } else {
+    if (!state.annotationData[imageFilename]) {
+        // 만약의 경우 데이터가 없는 경우를 대비해 기본 구조를 생성합니다.
         state.updateAnnotationData(imageFilename, { image_path: imageFilename, objects: [] });
     }
-    state.pushHistory(JSON.parse(JSON.stringify(state.annotationData[imageFilename].objects)));
+
+    // 현재 객체 상태를 히스토리에 추가합니다.
+    const currentObjects = state.annotationData[imageFilename].objects;
+    state.pushHistory(JSON.parse(JSON.stringify(currentObjects)));
 }
 
-export function saveCurrentAnnotation() {
-    if (state.currentImageIndex < 0) return;
-    const filename = state.imageFiles[state.currentImageIndex].name;
-    const output = state.annotationData[filename];
+export async function saveAllAnnotationsToZip() {
+    if (Object.keys(state.annotationData).length === 0) {
+        showNotification('저장할 데이터가 없습니다.', 'info', ui);
+        return;
+    }
 
-    output.objects.forEach(obj => {
-        if (obj.bbox) {
-            const [x1, y1, x2, y2] = obj.bbox;
-            obj.bbox = [Math.min(x1, x2), Math.min(y1, y2), Math.max(x1, x2), Math.max(y1, y2)];
+    showNotification('ZIP 파일 생성 중...', 'info', ui);
+
+    try {
+        const zip = new JSZip();
+
+        for (const filename in state.annotationData) {
+            if (Object.prototype.hasOwnProperty.call(state.annotationData, filename)) {
+                const output = state.annotationData[filename];
+
+                // BBox 좌표 정규화
+                output.objects.forEach(obj => {
+                    if (obj.bbox) {
+                        const [x1, y1, x2, y2] = obj.bbox;
+                        obj.bbox = [Math.min(x1, x2), Math.min(y1, y2), Math.max(x1, x2), Math.max(y1, y2)];
+                    }
+                });
+
+                const jsonString = JSON.stringify(output, null, 2);
+                const jsonFilename = filename.replace(/\.[^/.]+$/, "") + ".json";
+                zip.file(jsonFilename, jsonString);
+            }
         }
-    });
 
-    const blob = new Blob([JSON.stringify(output, null, 2)], { type: 'application/json' });
-    const a = Object.assign(document.createElement('a'), {
-        href: URL.createObjectURL(blob),
-        download: filename.replace(/\.[^/.]+$/, "") + ".json"
-    });
-    a.click();
-    URL.revokeObjectURL(a.href);
-    state.resetHistory();
-    state.pushHistory(JSON.parse(JSON.stringify(output.objects)));
-    showNotification(`${a.download} 저장 완료`, 'success', ui);
+        const zipBlob = await zip.generateAsync({ type: "blob" });
+        const a = Object.assign(document.createElement('a'), {
+            href: URL.createObjectURL(zipBlob),
+            download: `annotations_${new Date().toISOString().slice(0,10)}.zip`
+        });
+        a.click();
+        URL.revokeObjectURL(a.href);
+
+        showNotification('모든 JSON 파일이 ZIP으로 저장되었습니다.', 'success', ui);
+    } catch (error) {
+        showNotification(`ZIP 생성 오류: ${error.message}`, 'error', ui);
+        console.error("Failed to create ZIP file:", error);
+    }
 }


### PR DESCRIPTION
I've refactored the data handling logic to manage all annotations in memory. This prevents data loss when you navigate between images and allows for adding new labels to previously unlabeled images.

Key changes:
- On directory load, all existing JSON files are read into an in-memory state object. Images without JSONs are initialized with an empty annotation structure.
- Image navigation now reads from the in-memory store instead of the file system, preserving any changes made during the session.
- I replaced the 'Save JSON' for a single file with a 'Save All as ZIP' feature. This function iterates through all annotations in memory, creates a JSON file for each, and bundles them into a single downloadable ZIP archive.
- I integrated the JSZip library to handle client-side ZIP creation.
- I also updated the UI elements and event listeners to reflect the new functionality.