### PR TITLE
오른쪽 패널의 객체 상세 정보를 한 줄에 표시하도록 수정했습니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         </main>
 
         <!-- 오른쪽 패널 -->
-        <aside class="w-1/4 lg:w-1/5 rounded-2xl shadow-lg flex flex-col" style="background-color: var(--md-sys-color-surface-container);">
+        <aside class="w-2/5 rounded-2xl shadow-lg flex flex-col" style="background-color: var(--md-sys-color-surface-container);">
             <div class="p-4 border-b space-y-4" style="border-color: var(--md-sys-color-outline-variant);">
                 <div id="class-selector-wrapper" class="hidden">
                     <label for="class-selector" class="block text-sm font-medium mb-1">새 객체 클래스</label>

--- a/src/ui.js
+++ b/src/ui.js
@@ -244,13 +244,22 @@ export function updateKeypointListUI(obj) {
         return;
     }
 
+    const header = document.createElement('div');
+    header.className = 'keypoint-header p-2 text-xs font-bold';
+    header.innerHTML = `
+        <span class="col-label">라벨</span>
+        <span class="col-coords">좌표</span>
+        <span class="col-vis">Visibility</span>
+    `;
+    keypointListEl.appendChild(header);
+
     const points = obj.keypoints;
     const labels = state.config[obj.className].labels;
 
     labels.forEach((label, index) => {
         const point = points[index];
         const item = document.createElement('div');
-        item.className = 'keypoint-item p-2 text-xs rounded-lg cursor-pointer transition-colors space-y-2';
+        item.className = 'keypoint-item p-2 text-xs rounded-lg cursor-pointer transition-colors flex items-center';
         if (index === state.appState.selectedPointIndex) item.classList.add('selected');
 
         const visibilityRadios = [0, 1, 2].map(v => `
@@ -261,20 +270,14 @@ export function updateKeypointListUI(obj) {
         `).join('');
 
         item.innerHTML = `
-            <div class="flex justify-between items-center">
-                <span class="font-semibold">${index + 1}. ${label}</span>
+            <span class="col-label font-semibold truncate">${index + 1}. ${label}</span>
+            <div class="col-coords flex items-center gap-1">
+                <span class="text-gray-400">X:</span>
+                <input type="number" value="${point.x.toFixed(1)}" class="w-full rounded px-1 py-0.5 text-white">
+                <span class="text-gray-400">Y:</span>
+                <input type="number" value="${point.y.toFixed(1)}" class="w-full rounded px-1 py-0.5 text-white">
             </div>
-            <div class="grid grid-cols-2 gap-x-2 gap-y-1">
-                <div class="flex items-center">
-                    <span class="mr-1 text-gray-400">X:</span>
-                    <input type="number" value="${point.x.toFixed(1)}" class="w-full rounded px-1 py-0.5 text-white">
-                </div>
-                <div class="flex items-center">
-                    <span class="mr-1 text-gray-400">Y:</span>
-                    <input type="number" value="${point.y.toFixed(1)}" class="w-full rounded px-1 py-0.5 text-white">
-                </div>
-            </div>
-            <div class="flex justify-around items-center pt-1">
+            <div class="col-vis flex justify-around items-center">
                 ${visibilityRadios}
             </div>
         `;

--- a/styles.css
+++ b/styles.css
@@ -48,6 +48,18 @@ body {
 .object-item.selected { background-color: var(--md-sys-color-secondary-container); color: var(--md-sys-color-on-secondary-container); }
 .keypoint-item.selected { background-color: var(--md-sys-color-surface-container-high); }
 
+.keypoint-header {
+    display: flex;
+    align-items: center;
+    color: var(--md-sys-color-on-surface-variant);
+    border-bottom: 1px solid var(--md-sys-color-outline-variant);
+    margin-bottom: 4px;
+}
+
+.col-label { flex: 0 0 120px; padding-right: 8px; }
+.col-coords { flex: 1 1 auto; }
+.col-vis { flex: 0 0 150px; text-align: center; }
+
 input[type=number] {
     background-color: var(--md-sys-color-surface-container-low);
     border: 1px solid var(--md-sys-color-outline-variant); border-radius: 4px;


### PR DESCRIPTION
- `index.html`: 오른쪽 패널의 너비를 늘려 한 줄에 모든 정보가 표시될 공간을 확보했습니다.
- `src/ui.js`: 키포인트 목록 위에 "라벨", "좌표", "visibility" 헤더를 추가하고, 각 키포인트의 정보가 한 줄에 표시되도록 HTML 구조를 수정했습니다.
- `styles.css`: 새로운 한 줄 레이아웃과 헤더가 올바르게 정렬되고 표시되도록 CSS 스타일을 추가했습니다.