### PR TITLE
리사이즈 기능 추가 후 발생한 렌더링 버그를 수정했습니다.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { initUI } from './ui.js';
 import { initializeEventListeners } from './events.js';
+import { handleResize } from './canvas.js';
 
 function initialize() {
     initUI();
@@ -9,7 +10,8 @@ function initialize() {
         sizes: [75, 25],
         minSize: [200, 300],
         gutterSize: 8,
-        cursor: 'col-resize'
+        cursor: 'col-resize',
+        onDrag: handleResize
     });
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -16,7 +16,7 @@ export function initUI() {
         imageProgress: document.getElementById('imageProgress'),
         canvas: document.getElementById('mainCanvas'),
         ctx: document.getElementById('mainCanvas').getContext('2d'),
-        canvasWrapper: document.getElementById('canvas-wrapper'),
+        canvasWrapper: document.getElementById('split-0'),
         canvasLoader: document.getElementById('canvas-loader'),
         btnAddObject: document.getElementById('btnAddObject'),
         configHelp: document.getElementById('config-help'),


### PR DESCRIPTION
- `main.js`: `split.js`의 `onDrag` 콜백에서 `handleResize` 함수를 호출하여 캔버스 크기가 조절되도록 수정했습니다.
- `ui.js`: 캔버스 wrapper의 ID가 변경됨에 따라 `ui.js`의 참조를 수정했습니다.