### PR TITLE
삭제 확인 팝업에서 포커스 문제를 수정했습니다.

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -15,11 +15,14 @@ export function showDeleteConfirmModal() {
         </div>
     `;
     document.body.appendChild(modal);
-    document.getElementById('btnModalConfirm').addEventListener('click', () => {
+    const confirmButton = document.getElementById('btnModalConfirm');
+    confirmButton.addEventListener('click', () => {
         performDeleteObject();
         hideDeleteConfirmModal();
     });
     document.getElementById('btnModalCancel').addEventListener('click', hideDeleteConfirmModal);
+
+    confirmButton.focus();
 }
 
 function hideDeleteConfirmModal() {


### PR DESCRIPTION
- `src/modal.js`: 삭제 확인 팝업이 나타날 때 '삭제' 버튼에 자동으로 포커스를 주도록 수정하여, 엔터 키를 눌렀을 때 팝업이 중복으로 뜨는 문제를 해결했습니다.