### PR TITLE
오른쪽 패널의 스크롤바 및 툴팁 잘림 문제를 수정했습니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
                 </div>
                 <button id="btnAddObject" class="btn btn-filled w-full" disabled>+ 객체 추가 (A)</button>
             </div>
-            <div class="flex-grow overflow-y-auto">
+            <div class="flex-grow details-scroll-container">
                 <div id="config-help" class="p-4 text-sm" style="color: var(--md-sys-color-on-surface-variant);"></div>
                 <div id="object-list-wrapper" class="p-2 space-y-2"></div>
                 <div id="details-wrapper" class="p-2 border-t hidden" style="border-color: var(--md-sys-color-outline-variant);"></div>

--- a/styles.css
+++ b/styles.css
@@ -83,10 +83,10 @@ body {
     position: absolute;
     z-index: 1;
     bottom: 125%;
-    left: 50%;
-    margin-left: -110px;
+    left: -100px;
     opacity: 0;
     transition: opacity 0.3s;
+    white-space: normal;
 }
 
 .tooltip::after {
@@ -103,6 +103,10 @@ body {
 .tooltip-container:hover .tooltip {
     visibility: visible;
     opacity: 1;
+}
+
+.details-scroll-container {
+    overflow: visible;
 }
 
 .gutter {


### PR DESCRIPTION
- `index.html`: 불필요한 `overflow-y-auto` 클래스를 제거하고 새로운 클래스를 추가했습니다.
- `styles.css`: `overflow` 속성을 조정하여 스크롤바를 제거하고, 툴팁의 위치를 조정하여 잘리지 않도록 수정했습니다.