### PR TITLE
가로 스크롤바를 제거하고 툴팁 위치를 재조정했습니다.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -83,7 +83,7 @@ body {
     position: absolute;
     z-index: 1;
     bottom: 125%;
-    left: -120px;
+    left: -140px;
     opacity: 0;
     transition: opacity 0.3s;
     white-space: normal;
@@ -107,6 +107,7 @@ body {
 
 .details-scroll-container {
     overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .details-scroll-container::-webkit-scrollbar {


### PR DESCRIPTION
- `styles.css`: `.details-scroll-container`의 `overflow` 속성을 `overflow-y: auto`와 `overflow-x: hidden`으로 변경하여 가로 스크롤바를 제거하고, `.tooltip`의 `left` 속성을 수정하여 세로 스크롤바에 가려지지 않도록 왼쪽으로 더 이동시켰습니다.