### PR TITLE
Fix incorrect color when drawing new bounding box

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -48,7 +48,8 @@ export function redrawCanvas() {
     });
 
     if (state.appState.mode === 'DRAWING_BBOX' && state.appState.currentBbox) {
-        drawBbox({ bbox: state.appState.currentBbox }, true, true);
+        const color = getColorForClass(state.appState.currentClass, allClasses);
+        drawBbox({ bbox: state.appState.currentBbox }, color, true, true);
     }
 
     ctx.restore();


### PR DESCRIPTION
When starting to draw a new bounding box, it was being drawn with the color of the previously selected object. This was because the `drawBbox` function was called with a boolean `true` for the color parameter instead of a valid color string.

The fix involves getting the color for the currently selected class from the application state and passing it to the `drawBbox` function. This ensures the new bounding box is always drawn with the correct color.

Additionally, the line is now drawn with a dashed style to provide better visual feedback that the box is actively being drawn.