### PR TITLE
feat: JSON 뷰어 사이드바 기능 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,41 @@
         </div>
     </header>
 
+    <!-- JSON Viewer Sidebar -->
+    <div id="json-sidebar-container">
+        <button id="json-sidebar-toggle" class="btn btn-icon" title="JSON Viewer">
+            <!-- Icon will be inserted by JS -->
+        </button>
+        <aside id="json-sidebar" class="shadow-lg">
+            <div class="p-4" style="background-color: var(--md-sys-color-surface-container-high);">
+                <h2 class="text-lg font-bold">JSON Viewer</h2>
+            </div>
+            <div class="flex p-2 gap-2" style="background-color: var(--md-sys-color-surface-container);">
+                <button id="btn-live-json" class="btn btn-tonal flex-grow text-sm">실시간 JSON</button>
+                <button id="btn-coco-json" class="btn btn-tonal flex-grow text-sm">COCO 포맷</button>
+            </div>
+            <div id="json-content-wrapper" class="flex-grow p-2 overflow-y-auto">
+                <!-- Live JSON Content -->
+                <div id="live-json-content">
+                    <div class="flex justify-end gap-2 mb-2">
+                        <button id="btn-copy-live" class="btn btn-tonal text-xs">복사</button>
+                        <button id="btn-download-live" class="btn btn-tonal text-xs">다운로드</button>
+                    </div>
+                    <pre><code id="live-json-output" class="text-xs">{}</code></pre>
+                </div>
+                <!-- COCO JSON Content -->
+                <div id="coco-json-content" class="hidden">
+                    <div class="flex justify-end gap-2 mb-2">
+                        <button id="btn-copy-coco" class="btn btn-tonal text-xs">복사</button>
+                        <button id="btn-download-coco" class="btn btn-tonal text-xs">다운로드</button>
+                    </div>
+                    <pre><code id="coco-json-output" class="text-xs">{}</code></pre>
+                </div>
+            </div>
+        </aside>
+    </div>
+
+
     <!-- 메인 컨텐츠 영역 -->
     <div id="split-container" class="flex-grow flex p-4 gap-4 overflow-hidden">
         <!-- 중앙 캔버스 -->

--- a/src/dataExporter.js
+++ b/src/dataExporter.js
@@ -1,0 +1,98 @@
+import * as state from './state.js';
+
+/**
+ * Returns the annotation data for the current image as a formatted JSON string.
+ */
+export function exportAsLiveJson() {
+    const currentFile = state.imageFiles[state.currentImageIndex];
+    if (!currentFile) return '{}';
+
+    const data = state.annotationData[currentFile.name] || {};
+    return JSON.stringify(data, null, 2);
+}
+
+/**
+ * Converts all annotation data to the COCO format and returns it as a JSON string.
+ */
+export function exportAsCocoFormat() {
+    if (!state.config || Object.keys(state.annotationData).length === 0) {
+        return JSON.stringify({
+            info: { description: 'Pose Estimation Labeling Tool Export' },
+            licenses: [],
+            images: [],
+            annotations: [],
+            categories: []
+        }, null, 2);
+    }
+
+    const categories = Object.keys(state.config).map((className, i) => ({
+        id: i + 1,
+        name: className,
+        supercategory: 'common',
+        keypoints: state.config[className].labels,
+        skeleton: state.config[className].skeleton,
+    }));
+
+    const images = [];
+    const annotations = [];
+    let annotationId = 1;
+
+    for (let i = 0; i < state.imageFiles.length; i++) {
+        const file = state.imageFiles[i];
+        const imageData = state.annotationData[file.name];
+        if (!imageData) continue;
+
+        images.push({
+            id: i + 1,
+            width: imageData.image_width,
+            height: imageData.image_height,
+            file_name: file.name,
+            license: 1,
+            date_captured: new Date().toISOString(),
+        });
+
+        imageData.objects.forEach((obj, objIndex) => {
+            const category = categories.find(c => c.name === obj.className);
+            if (!category) return;
+
+            // Bbox: [x_min, y_min, width, height]
+            const bbox = [
+                obj.bbox[0],
+                obj.bbox[1],
+                obj.bbox[2] - obj.bbox[0],
+                obj.bbox[3] - obj.bbox[1],
+            ];
+
+            // Keypoints: [x1, y1, v1, x2, y2, v2, ...]
+            const keypoints = obj.keypoints.flatMap(p => [p.x, p.y, p.visible]);
+            const numKeypoints = obj.keypoints.filter(p => p.visible > 0).length;
+
+            annotations.push({
+                id: annotationId++,
+                image_id: i + 1,
+                category_id: category.id,
+                segmentation: [], // Not supported in this tool
+                area: bbox[2] * bbox[3], // width * height
+                bbox: bbox,
+                iscrowd: 0,
+                num_keypoints: numKeypoints,
+                keypoints: keypoints,
+            });
+        });
+    }
+
+    const cocoData = {
+        info: {
+            description: 'Pose Estimation Labeling Tool Export',
+            year: new Date().getFullYear(),
+            version: '1.0',
+            date_created: new Date().toISOString(),
+        },
+        licenses: [{ id: 1, name: 'Default License', url: '' }],
+        categories: categories,
+        images: images,
+        annotations: annotations,
+    };
+
+    return JSON.stringify(cocoData, null, 2);
+}

--- a/src/events.js
+++ b/src/events.js
@@ -1,7 +1,7 @@
 import * as state from './state.js';
-import { ui, updateAllUI, updateBboxInfoUI, updateKeypointListUI, updateInfoBarUI } from './ui.js';
+import { ui, updateAllUI, updateBboxInfoUI, updateKeypointListUI, updateInfoBarUI, toggleJsonSidebar, switchJsonViewTab } from './ui.js';
 import { redrawCanvas, centerImage, handleResize } from './canvas.js';
-import { getMousePos, screenToWorld, isPointInBbox, getResizeHandleAt, showNotification } from './utils.js';
+import { getMousePos, screenToWorld, isPointInBbox, getResizeHandleAt, showNotification, copyToClipboard, downloadFile } from './utils.js';
 import { navigateImage, saveAllAnnotationsToZip, handleConfigFile, handleDirectorySelection } from './file.js';
 import { showDeleteConfirmModal, isModalOpen, hideDeleteConfirmModal } from './modal.js';
 import { getKeyToActionMap } from './shortcutManager.js';
@@ -94,6 +94,20 @@ export function initializeEventListeners() {
             changeObjectClass(e.target.value);
         }
     });
+
+    // JSON Sidebar
+    ui.jsonSidebarToggle.addEventListener('click', toggleJsonSidebar);
+    ui.btnLiveJson.addEventListener('click', () => switchJsonViewTab('live'));
+    ui.btnCocoJson.addEventListener('click', () => switchJsonViewTab('coco'));
+
+    ui.btnCopyLive.addEventListener('click', () => copyToClipboard(ui.liveJsonOutput.textContent, ui));
+    ui.btnDownloadLive.addEventListener('click', () => {
+        const filename = state.imageFiles[state.currentImageIndex]?.name.replace(/\.[^/.]+$/, "") + ".json";
+        downloadFile(ui.liveJsonOutput.textContent, filename || 'annotation.json');
+    });
+
+    ui.btnCopyCoco.addEventListener('click', () => copyToClipboard(ui.cocoJsonOutput.textContent, ui));
+    ui.btnDownloadCoco.addEventListener('click', () => downloadFile(ui.cocoJsonOutput.textContent, 'coco_annotations.json'));
 }
 
 function handleMouseDown(e) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -3,6 +3,7 @@ import { redrawCanvas } from './canvas.js';
 import { formatBytes, showNotification, getColorForClass } from './utils.js';
 import * as shortcutManager from './shortcutManager.js';
 import { setCustomColor } from './colorManager.js';
+import { exportAsCocoFormat, exportAsLiveJson } from './dataExporter.js';
 
 export const ui = {};
 let tempShortcutConfig = {};
@@ -50,8 +51,23 @@ export function initUI() {
         shortcutList: document.getElementById('shortcutList'),
         btnResetShortcuts: document.getElementById('btnResetShortcuts'),
         btnSaveShortcuts: document.getElementById('btnSaveShortcuts'),
+
+        // JSON Sidebar
+        jsonSidebar: document.getElementById('json-sidebar'),
+        jsonSidebarToggle: document.getElementById('json-sidebar-toggle'),
+        btnLiveJson: document.getElementById('btn-live-json'),
+        btnCocoJson: document.getElementById('btn-coco-json'),
+        liveJsonContent: document.getElementById('live-json-content'),
+        cocoJsonContent: document.getElementById('coco-json-content'),
+        liveJsonOutput: document.getElementById('live-json-output'),
+        cocoJsonOutput: document.getElementById('coco-json-output'),
+        btnCopyLive: document.getElementById('btn-copy-live'),
+        btnDownloadLive: document.getElementById('btn-download-live'),
+        btnCopyCoco: document.getElementById('btn-copy-coco'),
+        btnDownloadCoco: document.getElementById('btn-download-coco'),
     });
 
+    ui.jsonSidebarToggle.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5" /></svg>`;
     ui.btnPrev.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" /></svg>`;
     ui.btnNext.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" /></svg>`;
     ui.btnShortcutSettings.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.532 1.532 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.532 1.532 0 01-.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" /></svg>`;
@@ -84,6 +100,9 @@ export function initUI() {
         populateShortcutModal();
         showNotification('단축키가 기본값으로 초기화되었습니다.', 'info', ui);
     });
+
+    // Set initial state for JSON viewer
+    switchJsonViewTab('live');
     ui.classColorIndicator.addEventListener('click', () => {
         const colorInput = document.createElement('input');
         colorInput.type = 'color';
@@ -182,6 +201,7 @@ export function updateAllUI() {
     updateInfoBarUI();
     updateModeIndicatorUI();
     updateClassSelectorUI();
+    updateJsonView();
 }
 
 export function updateClassSelectorUI() {
@@ -320,6 +340,37 @@ export function updateDetailsPanelUI() {
     updateBboxInfoUI(obj);
     updateKeypointListUI(obj);
 }
+
+export function toggleJsonSidebar() {
+    ui.jsonSidebar.classList.toggle('active');
+    ui.jsonSidebarToggle.classList.toggle('active');
+}
+
+export function switchJsonViewTab(tab) {
+    if (tab === 'live') {
+        ui.liveJsonContent.classList.remove('hidden');
+        ui.cocoJsonContent.classList.add('hidden');
+        ui.btnLiveJson.classList.add('active');
+        ui.btnCocoJson.classList.remove('active');
+    } else {
+        ui.liveJsonContent.classList.add('hidden');
+        ui.cocoJsonContent.classList.remove('hidden');
+        ui.btnLiveJson.classList.remove('active');
+        ui.btnCocoJson.classList.add('active');
+    }
+}
+
+export function updateJsonView() {
+    if (state.currentImageIndex < 0) {
+        ui.liveJsonOutput.textContent = '{}';
+        ui.cocoJsonOutput.textContent = '{}';
+        return;
+    }
+
+    ui.liveJsonOutput.textContent = exportAsLiveJson();
+    ui.cocoJsonOutput.textContent = exportAsCocoFormat();
+}
+
 
 function updateClassInfoUI(obj) {
     const classInfoEl = document.getElementById('class-info');

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,3 +75,24 @@ export function getColorForClass(className, allClassNames = []) {
     }
     return CLASS_COLORS[index % CLASS_COLORS.length];
 }
+
+export function copyToClipboard(text, ui) {
+    navigator.clipboard.writeText(text).then(() => {
+        showNotification('클립보드에 복사되었습니다.', 'success', ui);
+    }).catch(err => {
+        showNotification('복사에 실패했습니다.', 'error', ui);
+        console.error('클립보드 복사 실패:', err);
+    });
+}
+
+export function downloadFile(content, filename) {
+    const blob = new Blob([content], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}

--- a/styles.css
+++ b/styles.css
@@ -181,3 +181,71 @@ input[type=number] { -moz-appearance: textfield; }
 #toast-popup.success { background-color: var(--md-sys-color-primary-container); color: var(--md-sys-color-on-primary-container); }
 #toast-popup.error { background-color: var(--md-sys-color-error-container); color: var(--md-sys-color-error); }
 #toast-popup.info { background-color: var(--md-sys-color-secondary-container); color: var(--md-sys-color-on-secondary-container); }
+
+/* JSON Viewer Sidebar */
+#json-sidebar-container {
+    position: fixed;
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
+    z-index: 40; /* Below modal overlay (50) */
+}
+
+#json-sidebar-toggle {
+    position: absolute;
+    left: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 32px;
+    height: 100px;
+    border-radius: 0 16px 16px 0;
+    padding: 0;
+    background-color: var(--md-sys-color-surface-container-high);
+    color: var(--md-sys-color-on-surface-variant);
+    box-shadow: 2px 0 8px rgba(0,0,0,0.2);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#json-sidebar-toggle.active {
+    left: 408px; /* sidebar width + 8px */
+}
+
+#json-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 400px;
+    height: 100%;
+    background-color: var(--md-sys-color-surface-container);
+    display: flex;
+    flex-direction: column;
+    transform: translateX(-100%);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 39;
+}
+
+#json-sidebar.active {
+    transform: translateX(0);
+}
+
+#json-content-wrapper {
+    background-color: var(--md-sys-color-surface-container-low);
+    margin: 8px;
+    border-radius: 8px;
+    flex-grow: 1;
+}
+
+#json-content-wrapper pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    background-color: var(--md-sys-color-surface);
+    padding: 8px;
+    border-radius: 4px;
+    max-height: calc(100vh - 250px); /* Adjust as needed */
+    overflow-y: auto;
+}
+
+#json-sidebar .btn-tonal.active {
+    background-color: var(--md-sys-color-primary);
+    color: var(--md-sys-color-on-primary);
+}


### PR DESCRIPTION
왼쪽 엣지에 새로운 사이드바 UI를 추가하여 라벨링 데이터를 실시간으로 확인할 수 있는 기능을 구현했습니다.

주요 변경 사항:
- 'index.html': 사이드바와 토글 버튼의 HTML 구조를 추가했습니다.
- 'styles.css': 사이드바의 레이아웃, 스타일, 열고 닫는 애니메이션을 위한 CSS를 추가했습니다.
- 'src/ui.js': 사이드바의 DOM 요소를 관리하고, 상태에 따라 UI를 업데이트하는 로직을 추가했습니다.
- 'src/events.js': 사이드바 토글, 탭 전환, 데이터 복사 및 다운로드 버튼에 대한 이벤트 리스너를 연결했습니다.
- 'src/dataExporter.js': 새로운 모듈을 추가하여 현재 주석 데이터를 실시간 JSON과 COCO 포맷으로 변환하는 로직을 구현했습니다.
- 'src/utils.js': 클립보드 복사 및 파일 다운로드를 위한 헬퍼 함수를 추가했습니다.

기능:
- 세로 북마크 스타일의 버튼으로 사이드바를 토글할 수 있습니다.
- 사이드바 내에서 '실시간 JSON'과 'COCO 포맷' 탭을 전환할 수 있습니다.
- 각 뷰의 데이터를 클립보드에 복사하는 버튼이 있습니다.
- 각 뷰의 데이터를 `.json` 파일로 다운로드하는 버튼이 있습니다.
- 주석 데이터가 변경되면 JSON 뷰가 자동으로 업데이트됩니다.